### PR TITLE
Change triangles to squares on April 1st

### DIFF
--- a/src/components/canvas/index.tsx
+++ b/src/components/canvas/index.tsx
@@ -37,6 +37,7 @@ export function Canvas() {
 
   const TRIANGLE_HEIGHT = 64;
   const TRIANGLE_WIDTH = 64;
+  const SQUARE_SIZE = 64;
 
   useEffect(() => {
     if (typeof window === "undefined") {
@@ -100,6 +101,10 @@ export function Canvas() {
 
     ctx.clearRect(0, 0, viewportWidth, viewportHeight);
 
+    // Check if it's April 1st
+    const today = new Date();
+    const isAprilFools = today.getMonth() === 3 && today.getDate() === 1;
+
     if (y + TRIANGLE_HEIGHT >= canvasRef.current.height || y < 0) {
       currentColorId === COLORS.length - 1
         ? (currentColorId = 0)
@@ -121,7 +126,7 @@ export function Canvas() {
     x += dx * PUCK_SPEED;
     y += dy * PUCK_SPEED;
 
-    // draw a solid triangle
+    // draw a solid shape based on the date
     ctx.fillStyle = COLORS[currentColorId];
 
     // change blob bg
@@ -143,6 +148,7 @@ export function Canvas() {
     if (currentT === 1) {
       t1.style.opacity = "1";
       t4.style.opacity = "0";
+      if (isAprilFools) t1.textContent = "■"; // Change triangle to square UTF8 char
     }
     if (currentT === 2) {
       t1.style.opacity = "0";
@@ -155,14 +161,20 @@ export function Canvas() {
     if (currentT === 4) {
       t3.style.opacity = "0";
       t4.style.opacity = "1";
+      if (isAprilFools) t4.textContent = "■"; // Ensure all triangle UTF8 characters are changed to square
     }
 
-    // draw a triangle with the tip pointing up
-    ctx.beginPath();
-    ctx.moveTo(x + TRIANGLE_WIDTH / 2, y);
-    ctx.lineTo(x + TRIANGLE_WIDTH, y + TRIANGLE_HEIGHT);
-    ctx.lineTo(x, y + TRIANGLE_HEIGHT);
-    ctx.fill();
+    if (isAprilFools) {
+      // draw a square
+      ctx.fillRect(x, y, SQUARE_SIZE, SQUARE_SIZE);
+    } else {
+      // draw a triangle with the tip pointing up
+      ctx.beginPath();
+      ctx.moveTo(x + TRIANGLE_WIDTH / 2, y);
+      ctx.lineTo(x + TRIANGLE_WIDTH, y + TRIANGLE_HEIGHT);
+      ctx.lineTo(x, y + TRIANGLE_HEIGHT);
+      ctx.fill();
+    }
 
     window.requestAnimationFrame(render);
   };


### PR DESCRIPTION
Related to #10

Implements a playful feature in `src/components/canvas/index.tsx` that changes the shape rendered from a triangle to a square on April 1st, in line with the April Fools' Day theme. Additionally, it updates the UTF8 character representation for the shapes accordingly.

- **Date Check**: Adds a check to determine if the current date is April 1st. If so, the rendering logic switches from drawing triangles to squares.
- **Shape Rendering**: Modifies the canvas drawing logic to render a square instead of a triangle when it's April Fools' Day, using the same color logic as for triangles.
- **UTF8 Character Update**: Changes the UTF8 character for triangles to squares in the text content of certain elements on April 1st, ensuring the April Fools' theme is consistent across text and canvas renderings.
- **Position and Color Logic**: Maintains the existing logic for position updates and color changes as the shape moves across the canvas, ensuring the feature addition is seamless and does not disrupt the original functionality.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Hacksore/vercel.lol/issues/10?shareId=fd675513-c34c-405d-a385-1ac2fce2b9bd).